### PR TITLE
Fix Error Handling for Diary Repository

### DIFF
--- a/pkg/blog/diary.go
+++ b/pkg/blog/diary.go
@@ -1,6 +1,7 @@
 package blog
 
 import (
+	"errors"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -53,10 +54,15 @@ func NewDynamoDiaryRepository(sess *session.Session, tableName string) *DynamoDi
 	}
 }
 
+var ErrDiaryNotFound = errors.New("diary not found")
+
 func (r *DynamoDiaryRepository) GetDiary(memberName string, diaryId int) (*Diary, error) {
 	diary := new(Diary)
 	err := r.table.Get("member_name", memberName).Range("diary_id", dynamo.Equal, diaryId).One(diary)
 	if err != nil {
+		if err == dynamo.ErrNotFound {
+			return nil, ErrDiaryNotFound
+		}
 		return nil, err
 	}
 	return diary, nil

--- a/pkg/blog/hinatazaka_scraper.go
+++ b/pkg/blog/hinatazaka_scraper.go
@@ -25,14 +25,16 @@ func (s *HinatazakaScraper) GetLatestDiaries() ([]*Diary, error) {
 
 	res := []*Diary{}
 	for _, d := range latestDiaries {
-		diary, err := s.repo.GetDiary(d.MemberName, d.Id)
+		_, err := s.repo.GetDiary(d.MemberName, d.Id)
 		if err != nil {
+			// Check if the error is a "not found" error.
+			if err == ErrDiaryNotFound {
+				// The item is not in the database, so it's a new diary.
+				res = append(res, d)
+				continue
+			}
+			// Some other error occurred.
 			return nil, err
-		}
-
-		// Dynamoにデータがない場合
-		if diary.Id == 0 {
-			res = append(res, d)
 		}
 	}
 


### PR DESCRIPTION
## Changes
This PR fixes the error handling for cases when diary entries are not found in the database. Specifically, it:

+ Introduces a new error `ErrDiaryNotFound` in the `DynamoDiaryRepository` that is returned when a diary entry does not exist in the database.
+ Modifies the `GetDiary` function in the `DynamoDiaryRepository` to return the `ErrDiaryNotFound` error when an item is not found in the database.
+ Updates the `GetLatestDiaries` function in the `HinatazakaScraper` to correctly handle the `ErrDiaryNotFound` error and continue processing.

## Motivation
Previously, the GetDiary function would return a dynamo.ErrNotFound error when an item was not found, stopping the processing of diary entries prematurely. This forced callers of the function to know about the internal implementation of the repository, specifically that it used DynamoDB, and did not allow subsequent processing when the diary entry was not found in the database.

With these changes, callers of GetDiary only need to know about the ErrDiaryNotFound error. They do not need to know about the internal use of DynamoDB. This bug fix ensures that the processing of diary entries can continue even when a diary entry is not found in the database.