### PR TITLE
add menucommand of the specified member

### DIFF
--- a/app/webhook/command_handler.go
+++ b/app/webhook/command_handler.go
@@ -328,7 +328,7 @@ func (c *NicknameCommand) Description() string {
 	return "Get the nickname of a member. Usage: name [member]"
 }
 
-// MenuCommand is the command that shows some command buttons of the specified member.
+// MenuCommand is the command that shows the menu of member selection, or the menu of the specified member if accompanied by the member name.
 type MenuCommand struct {
 	bot *line.Linebot
 }
@@ -338,6 +338,12 @@ func (c *MenuCommand) Execute(ctx context.Context, event *linebot.Event, args []
 	logger.Info("Executing MenuCommand with args", zap.Any("args", args))
 
 	if len(args) < 2 {
+		message := line.CreateMenuFlexMessage()
+
+		err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
+		if err != nil {
+			return fmt.Errorf("NicknameCommand.Execute: %w", err)
+		}
 		return nil
 	}
 
@@ -357,7 +363,7 @@ func (c *MenuCommand) Execute(ctx context.Context, event *linebot.Event, args []
 	}
 
 	prof, _ := profile.ScrapeProfile(member)
-	message := line.CreateMenuFlexMessage(prof)
+	message := line.CreateMemberMenuFlexMessage(prof)
 
 	err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
 	if err != nil {

--- a/app/webhook/command_handler.go
+++ b/app/webhook/command_handler.go
@@ -356,9 +356,6 @@ func (c *MenuCommand) Execute(ctx context.Context, event *linebot.Event, args []
 	}
 
 	if !model.IsMember(member) {
-		if err := c.bot.ReplyTextMessages(ctx, event.ReplyToken, fmt.Sprintf("%sは存在しません。", member)); err != nil {
-			return fmt.Errorf("NicknameCommand.Execute: %w", err)
-		}
 		return nil
 	}
 
@@ -373,7 +370,7 @@ func (c *MenuCommand) Execute(ctx context.Context, event *linebot.Event, args []
 }
 
 func (c *MenuCommand) Description() string {
-	return "Get the nickname of a member. Usage: name [member]"
+	return "Get the general menu or the specified member menu. Usage: menu or menu [member]"
 }
 
 // type Subscriber struct {

--- a/app/webhook/postback_handler.go
+++ b/app/webhook/postback_handler.go
@@ -125,7 +125,7 @@ type PostbackCommandProfile struct {
 
 func (c *PostbackCommandProfile) Execute(ctx context.Context, event *linebot.Event, data *line.PostbackData) error {
 	logger := logging.LoggerFromContext(ctx)
-	logger.Info("Start executing postback command blog")
+	logger.Info("Start executing postback command profile")
 
 	member := data.Params[line.MemberKey]
 	if !model.IsMember(member) {
@@ -150,7 +150,7 @@ type PostbackCommandNickname struct {
 
 func (c *PostbackCommandNickname) Execute(ctx context.Context, event *linebot.Event, data *line.PostbackData) error {
 	logger := logging.LoggerFromContext(ctx)
-	logger.Info("Start executing postback command blog")
+	logger.Info("Start executing postback command nickname")
 
 	member := data.Params[line.MemberKey]
 	if !model.IsMember(member) {
@@ -180,46 +180,24 @@ type PostbackCommandSelect struct {
 	bot *line.Linebot
 }
 
+var actionToMessageMap = map[string]linebot.SendingMessage{
+	line.SubscribeLabel: line.CreateMemberSelectFlexMessage(line.NewSubscribeAction),
+	line.BlogLabel:      line.CreateMemberSelectFlexMessage(line.NewBlogAction),
+	line.ProfileLabel:   line.CreateMemberSelectFlexMessage(line.NewProfileAction),
+	line.NicknameLabel:  line.CreateMemberSelectFlexMessage(line.NewNicknameAction),
+}
+
 func (c *PostbackCommandSelect) Execute(ctx context.Context, event *linebot.Event, data *line.PostbackData) error {
 	logger := logging.LoggerFromContext(ctx)
-	logger.Info("Start executing postback command blog")
+	logger.Info("Start executing postback command select")
 
 	action := data.Params[line.ActionKey]
 
-	if action == line.SubscribeLabel {
-		message := line.CreateMemberSelectFlexMessage(line.NewSubscribeAction)
+	message := actionToMessageMap[action]
 
-		err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
-		if err != nil {
-			return fmt.Errorf("PostbackCommandSelect.Execute: %w", err)
-		}
-	}
-
-	if action == line.BlogLabel {
-		message := line.CreateMemberSelectFlexMessage(line.NewBlogAction)
-
-		err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
-		if err != nil {
-			return fmt.Errorf("PostbackCommandSelect.Execute: %w", err)
-		}
-	}
-
-	if action == line.ProfileLabel {
-		message := line.CreateMemberSelectFlexMessage(line.NewProfileAction)
-
-		err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
-		if err != nil {
-			return fmt.Errorf("PostbackCommandSelect.Execute: %w", err)
-		}
-	}
-
-	if action == line.NicknameLabel {
-		message := line.CreateMemberSelectFlexMessage(line.NewNicknameAction)
-
-		err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
-		if err != nil {
-			return fmt.Errorf("PostbackCommandSelect.Execute: %w", err)
-		}
+	err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
+	if err != nil {
+		return fmt.Errorf("PostbackCommandSelect.Execute: %w", err)
 	}
 
 	return nil

--- a/app/webhook/postback_handler.go
+++ b/app/webhook/postback_handler.go
@@ -11,6 +11,7 @@ import (
 	"zephyr/pkg/service"
 
 	"github.com/line/line-bot-sdk-go/v7/linebot"
+	"go.uber.org/zap"
 )
 
 type PostbackCommand interface {
@@ -195,6 +196,7 @@ func (c *PostbackCommandSelect) Execute(ctx context.Context, event *linebot.Even
 
 	messageFunc, ok := labelToActionMap[label]
 	if !ok {
+		logger.Warn("Unknown label", zap.String("label", label))
 		return nil
 	}
 

--- a/app/webhook/postback_handler.go
+++ b/app/webhook/postback_handler.go
@@ -27,6 +27,7 @@ func (h *Handler) getPostbackCommandMap() PostbackCommandMap {
 		line.PostbackActionBlog:       &PostbackCommandBlog{h.bot},
 		line.PostbackActionProfile:    &PostbackCommandProfile{h.bot},
 		line.PostbackActionNickname:   &PostbackCommandNickname{h.bot},
+		line.PostbackActionSelect:     &PostbackCommandSelect{h.bot},
 	}
 }
 
@@ -142,7 +143,7 @@ func (c *PostbackCommandProfile) Execute(ctx context.Context, event *linebot.Eve
 	return nil
 }
 
-// PostbackCommandNickname is a command to the nickname of the specified member.
+// PostbackCommandNickname is a command to show the nickname of the specified member.
 type PostbackCommandNickname struct {
 	bot *line.Linebot
 }
@@ -171,5 +172,55 @@ func (c *PostbackCommandNickname) Execute(ctx context.Context, event *linebot.Ev
 	if err != nil {
 		return fmt.Errorf("PostbackCommandNickname.Execute: %w", err)
 	}
+	return nil
+}
+
+// PostbackCommandSelect is a command to show the selectmenu of the member.
+type PostbackCommandSelect struct {
+	bot *line.Linebot
+}
+
+func (c *PostbackCommandSelect) Execute(ctx context.Context, event *linebot.Event, data *line.PostbackData) error {
+	logger := logging.LoggerFromContext(ctx)
+	logger.Info("Start executing postback command blog")
+
+	action := data.Params[line.ActionKey]
+
+	if action == line.SubscribeLabel {
+		message := line.CreateMemberSelectFlexMessage(line.NewSubscribeAction)
+
+		err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
+		if err != nil {
+			return fmt.Errorf("PostbackCommandSelect.Execute: %w", err)
+		}
+	}
+
+	if action == line.BlogLabel {
+		message := line.CreateMemberSelectFlexMessage(line.NewBlogAction)
+
+		err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
+		if err != nil {
+			return fmt.Errorf("PostbackCommandSelect.Execute: %w", err)
+		}
+	}
+
+	if action == line.ProfileLabel {
+		message := line.CreateMemberSelectFlexMessage(line.NewProfileAction)
+
+		err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
+		if err != nil {
+			return fmt.Errorf("PostbackCommandSelect.Execute: %w", err)
+		}
+	}
+
+	if action == line.NicknameLabel {
+		message := line.CreateMemberSelectFlexMessage(line.NewNicknameAction)
+
+		err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
+		if err != nil {
+			return fmt.Errorf("PostbackCommandSelect.Execute: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/app/webhook/postback_handler.go
+++ b/app/webhook/postback_handler.go
@@ -193,7 +193,12 @@ func (c *PostbackCommandSelect) Execute(ctx context.Context, event *linebot.Even
 
 	label := data.Params[line.ActionKey]
 
-	message := line.CreateMemberSelectFlexMessage(labelToActionMap[label])
+	messageFunc, ok := labelToActionMap[label]
+	if !ok {
+		return nil
+	}
+
+	message := line.CreateMemberSelectFlexMessage(messageFunc)
 
 	err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
 	if err != nil {

--- a/app/webhook/postback_handler.go
+++ b/app/webhook/postback_handler.go
@@ -180,20 +180,20 @@ type PostbackCommandSelect struct {
 	bot *line.Linebot
 }
 
-var actionToMessageMap = map[string]linebot.SendingMessage{
-	line.SubscribeLabel: line.CreateMemberSelectFlexMessage(line.NewSubscribeAction),
-	line.BlogLabel:      line.CreateMemberSelectFlexMessage(line.NewBlogAction),
-	line.ProfileLabel:   line.CreateMemberSelectFlexMessage(line.NewProfileAction),
-	line.NicknameLabel:  line.CreateMemberSelectFlexMessage(line.NewNicknameAction),
+var labelToActionMap = map[string]line.PostbackActionGenerator{
+	line.SubscribeLabel: line.NewSubscribeAction,
+	line.BlogLabel:      line.NewBlogAction,
+	line.ProfileLabel:   line.NewProfileAction,
+	line.NicknameLabel:  line.NewNicknameAction,
 }
 
 func (c *PostbackCommandSelect) Execute(ctx context.Context, event *linebot.Event, data *line.PostbackData) error {
 	logger := logging.LoggerFromContext(ctx)
 	logger.Info("Start executing postback command select")
 
-	action := data.Params[line.ActionKey]
+	label := data.Params[line.ActionKey]
 
-	message := actionToMessageMap[action]
+	message := line.CreateMemberSelectFlexMessage(labelToActionMap[label])
 
 	err := c.bot.ReplyMessage(ctx, event.ReplyToken, message)
 	if err != nil {

--- a/pkg/infrastructure/line/menu_messege.go
+++ b/pkg/infrastructure/line/menu_messege.go
@@ -1,0 +1,123 @@
+package line
+
+import (
+	"notify/pkg/model"
+	"notify/pkg/profile"
+
+	"github.com/line/line-bot-sdk-go/v7/linebot"
+)
+
+// CreateMenuFlexMessageはメニュー画面を生成
+func CreateMenuFlexMessage(prof *profile.Profile) linebot.SendingMessage {
+	content := createFlexMenuMessage(prof)
+
+	message := linebot.NewFlexMessage(prof.Name+"のメニュー", content).WithSender(linebot.NewSender(prof.Name, prof.ImageUrl))
+
+	return message
+}
+
+func createFlexMenuMessage(prof *profile.Profile) *linebot.BubbleContainer {
+	container := MegaBubbleContainer
+
+	container.Body = &linebot.BoxComponent{
+		Type:       linebot.FlexComponentTypeBox,
+		Layout:     linebot.FlexBoxLayoutTypeVertical,
+		Height:     "380px",
+		PaddingAll: "0px",
+		Contents: []linebot.FlexComponent{
+			&linebot.BoxComponent{
+				Type:   linebot.FlexComponentTypeBox,
+				Layout: linebot.FlexBoxLayoutTypeVertical,
+				Height: "70%",
+				Contents: []linebot.FlexComponent{
+					&linebot.BoxComponent{
+						Type:   linebot.FlexComponentTypeBox,
+						Layout: linebot.FlexBoxLayoutTypeVertical,
+						Contents: []linebot.FlexComponent{
+							&linebot.ImageComponent{
+								Type:       linebot.FlexComponentTypeImage,
+								URL:        prof.ImageUrl,
+								Size:       linebot.FlexImageSizeTypeFull,
+								AspectMode: linebot.FlexImageAspectModeTypeCover,
+							},
+						},
+					},
+				},
+				PaddingAll: "0px",
+			},
+			&linebot.BoxComponent{
+				Type:   linebot.FlexComponentTypeBox,
+				Layout: linebot.FlexBoxLayoutTypeVertical,
+				Margin: linebot.FlexComponentMarginTypeLg,
+				Contents: []linebot.FlexComponent{
+					&linebot.BoxComponent{
+						Type:   linebot.FlexComponentTypeBox,
+						Layout: linebot.FlexBoxLayoutTypeVertical,
+						Contents: []linebot.FlexComponent{
+							&linebot.BoxComponent{
+								Type:   linebot.FlexComponentTypeBox,
+								Layout: linebot.FlexBoxLayoutTypeHorizontal,
+								Contents: []linebot.FlexComponent{
+									&linebot.ButtonComponent{
+										Type:   linebot.FlexComponentTypeButton,
+										Action: NewSubscribeAction(prof.Name),
+										Margin: linebot.FlexComponentMarginTypeLg,
+										Style:  linebot.FlexButtonStyleTypeSecondary,
+										Color:  "#ffffff",
+									},
+									&linebot.ButtonComponent{
+										Type:   linebot.FlexComponentTypeButton,
+										Action: NewBlogAction(prof.Name),
+										Margin: linebot.FlexComponentMarginTypeLg,
+										Style:  linebot.FlexButtonStyleTypeSecondary,
+										Color:  "#ffffff",
+									},
+								},
+							},
+						},
+					},
+					&linebot.BoxComponent{
+						Type:   linebot.FlexComponentTypeBox,
+						Layout: linebot.FlexBoxLayoutTypeVertical,
+						Margin: linebot.FlexComponentMarginTypeLg,
+						Contents: []linebot.FlexComponent{
+							&linebot.BoxComponent{
+								Type:   linebot.FlexComponentTypeBox,
+								Layout: linebot.FlexBoxLayoutTypeHorizontal,
+								Contents: []linebot.FlexComponent{
+									&linebot.ButtonComponent{
+										Type:   linebot.FlexComponentTypeButton,
+										Action: NewProfileAction(prof.Name),
+										Margin: linebot.FlexComponentMarginTypeLg,
+										Style:  linebot.FlexButtonStyleTypeSecondary,
+										Color:  "#ffffff",
+									},
+									&linebot.ButtonComponent{
+										Type:   linebot.FlexComponentTypeButton,
+										Action: NewNicknameAction(prof.Name),
+										Margin: linebot.FlexComponentMarginTypeLg,
+										Style:  linebot.FlexButtonStyleTypeSecondary,
+										Color:  "#ffffff",
+									},
+								},
+							},
+						},
+					},
+				},
+				PaddingAll:      "15px",
+				BackgroundColor: "#464F69",
+				Position:        linebot.FlexComponentPositionTypeAbsolute,
+				OffsetBottom:    "0px",
+				OffsetStart:     "0px",
+				OffsetEnd:       "0px",
+			},
+		},
+	}
+
+	generationLabelText := model.MemberToGenerationMap[prof.Name] + "期生"
+	generationLabel := CreateLabelComponent(generationLabelText, "#ffffff", "#EC3D44")
+	firstBox := container.Body.Contents[0].(*linebot.BoxComponent)
+	firstBox.Contents = append(firstBox.Contents, generationLabel)
+
+	return &container
+}

--- a/pkg/infrastructure/line/menu_messege.go
+++ b/pkg/infrastructure/line/menu_messege.go
@@ -1,22 +1,217 @@
 package line
 
 import (
+	"fmt"
 	"notify/pkg/model"
 	"notify/pkg/profile"
 
 	"github.com/line/line-bot-sdk-go/v7/linebot"
 )
 
-// CreateMenuFlexMessageはメニュー画面を生成
-func CreateMenuFlexMessage(prof *profile.Profile) linebot.SendingMessage {
-	content := createFlexMenuMessage(prof)
+const iconUrl = "https://cdn.hinatazaka46.com/images/14/14d/a9bac831ed1e6a4fdd93c4271aa8a.jpg"
+
+// CreateMenuFlexMessageは汎用のメニュー画面を生成
+func CreateMenuFlexMessage() linebot.SendingMessage {
+	content := createFlexMenuMessage()
+
+	message := linebot.NewFlexMessage("日向坂メニュー", content).WithSender(linebot.NewSender("日向坂46", iconUrl))
+
+	return message
+}
+
+func createFlexMenuMessage() *linebot.BubbleContainer {
+	container := MegaBubbleContainer
+
+	container.Body = &linebot.BoxComponent{
+		Type:       linebot.FlexComponentTypeBox,
+		Layout:     linebot.FlexBoxLayoutTypeVertical,
+		Height:     "380px",
+		PaddingAll: "0px",
+		Contents: []linebot.FlexComponent{
+			&linebot.BoxComponent{
+				Type:   linebot.FlexComponentTypeBox,
+				Layout: linebot.FlexBoxLayoutTypeVertical,
+				Height: "70%",
+				Contents: []linebot.FlexComponent{
+					&linebot.BoxComponent{
+						Type:   linebot.FlexComponentTypeBox,
+						Layout: linebot.FlexBoxLayoutTypeVertical,
+						Contents: []linebot.FlexComponent{
+							&linebot.ImageComponent{
+								Type:       linebot.FlexComponentTypeImage,
+								URL:        iconUrl,
+								Size:       linebot.FlexImageSizeTypeFull,
+								AspectMode: linebot.FlexImageAspectModeTypeCover,
+							},
+						},
+					},
+				},
+				PaddingAll: "0px",
+			},
+			&linebot.BoxComponent{
+				Type:   linebot.FlexComponentTypeBox,
+				Layout: linebot.FlexBoxLayoutTypeVertical,
+				Margin: linebot.FlexComponentMarginTypeLg,
+				Contents: []linebot.FlexComponent{
+					&linebot.BoxComponent{
+						Type:   linebot.FlexComponentTypeBox,
+						Layout: linebot.FlexBoxLayoutTypeVertical,
+						Contents: []linebot.FlexComponent{
+							&linebot.BoxComponent{
+								Type:   linebot.FlexComponentTypeBox,
+								Layout: linebot.FlexBoxLayoutTypeHorizontal,
+								Contents: []linebot.FlexComponent{
+									&linebot.ButtonComponent{
+										Type:   linebot.FlexComponentTypeButton,
+										Action: NewSelectAction(SubscribeLabel),
+										Margin: linebot.FlexComponentMarginTypeLg,
+										Style:  linebot.FlexButtonStyleTypeSecondary,
+										Color:  "#ffffff",
+									},
+									&linebot.ButtonComponent{
+										Type:   linebot.FlexComponentTypeButton,
+										Action: NewSelectAction(BlogLabel),
+										Margin: linebot.FlexComponentMarginTypeLg,
+										Style:  linebot.FlexButtonStyleTypeSecondary,
+										Color:  "#ffffff",
+									},
+								},
+							},
+						},
+					},
+					&linebot.BoxComponent{
+						Type:   linebot.FlexComponentTypeBox,
+						Layout: linebot.FlexBoxLayoutTypeVertical,
+						Margin: linebot.FlexComponentMarginTypeLg,
+						Contents: []linebot.FlexComponent{
+							&linebot.BoxComponent{
+								Type:   linebot.FlexComponentTypeBox,
+								Layout: linebot.FlexBoxLayoutTypeHorizontal,
+								Contents: []linebot.FlexComponent{
+									&linebot.ButtonComponent{
+										Type:   linebot.FlexComponentTypeButton,
+										Action: NewSelectAction(ProfileLabel),
+										Margin: linebot.FlexComponentMarginTypeLg,
+										Style:  linebot.FlexButtonStyleTypeSecondary,
+										Color:  "#ffffff",
+									},
+									&linebot.ButtonComponent{
+										Type:   linebot.FlexComponentTypeButton,
+										Action: NewSelectAction(NicknameLabel),
+										Margin: linebot.FlexComponentMarginTypeLg,
+										Style:  linebot.FlexButtonStyleTypeSecondary,
+										Color:  "#ffffff",
+									},
+								},
+							},
+						},
+					},
+				},
+				PaddingAll:      "15px",
+				BackgroundColor: "#464F69",
+				Position:        linebot.FlexComponentPositionTypeAbsolute,
+				OffsetBottom:    "0px",
+				OffsetStart:     "0px",
+				OffsetEnd:       "0px",
+			},
+		},
+	}
+	return &container
+}
+
+type Action func(string) *linebot.PostbackAction
+
+// CreateMemberSelectFlexMessageはメンバー選択画面を生成
+func CreateMemberSelectFlexMessage(action Action) linebot.SendingMessage {
+	container := createFlexMemberSelectMessage(action)
+
+	outerContainer := &linebot.CarouselContainer{
+		Type:     linebot.FlexContainerTypeCarousel,
+		Contents: container,
+	}
+
+	message := linebot.NewFlexMessage("メンバー選択", outerContainer).WithSender(linebot.NewSender("日向坂46", iconUrl))
+
+	return message
+}
+
+func createFlexMemberSelectMessage(action Action) []*linebot.BubbleContainer {
+	contents := []*linebot.BubbleContainer{}
+	groupSize := 8
+
+	for i := 0; i < len(model.MemberList); i += groupSize {
+		content := MegaBubbleContainer
+		components := []linebot.FlexComponent{}
+
+		end := i + groupSize
+		if end > len(model.MemberList) {
+			end = len(model.MemberList)
+		}
+		group := model.MemberList[i:end]
+
+		for _, member := range group {
+			component := &linebot.BoxComponent{
+				Type:   linebot.FlexComponentTypeBox,
+				Layout: linebot.FlexBoxLayoutTypeHorizontal,
+				Margin: linebot.FlexComponentMarginTypeMd,
+				Contents: []linebot.FlexComponent{
+					&linebot.TextComponent{
+						Type:    linebot.FlexComponentTypeText,
+						Size:    linebot.FlexTextSizeTypeMd,
+						Wrap:    true,
+						Gravity: linebot.FlexComponentGravityTypeCenter,
+						Text:    fmt.Sprintf("·%s", member),
+						Color:   "#ffffff",
+						Weight:  linebot.FlexTextWeightTypeBold,
+					},
+					&linebot.ButtonComponent{
+						Type:    linebot.FlexComponentTypeButton,
+						Action:  action(member),
+						Height:  linebot.FlexButtonHeightTypeSm,
+						Gravity: linebot.FlexComponentGravityTypeCenter,
+						Style:   linebot.FlexButtonStyleTypeSecondary,
+						Color:   "#ffffff",
+					},
+				},
+			}
+			components = append(components, component)
+		}
+
+		content.Body = &linebot.BoxComponent{
+			Type:       linebot.FlexComponentTypeBox,
+			Layout:     linebot.FlexBoxLayoutTypeVertical,
+			Height:     "410px",
+			PaddingAll: "0px",
+			Contents: []linebot.FlexComponent{
+				&linebot.BoxComponent{
+					Type:            linebot.FlexComponentTypeBox,
+					Layout:          linebot.FlexBoxLayoutTypeVertical,
+					Contents:        components,
+					PaddingAll:      "20px",
+					BackgroundColor: "#464F69",
+					Position:        linebot.FlexComponentPositionTypeAbsolute,
+					OffsetBottom:    "0px",
+					OffsetStart:     "0px",
+					OffsetEnd:       "0px",
+				},
+			},
+		}
+		contents = append(contents, &content)
+	}
+
+	return contents
+}
+
+// CreateMemberMenuFlexMessageは特定メンバーのメニュー画面を生成
+func CreateMemberMenuFlexMessage(prof *profile.Profile) linebot.SendingMessage {
+	content := createFlexMemberMenuMessage(prof)
 
 	message := linebot.NewFlexMessage(prof.Name+"のメニュー", content).WithSender(linebot.NewSender(prof.Name, prof.ImageUrl))
 
 	return message
 }
 
-func createFlexMenuMessage(prof *profile.Profile) *linebot.BubbleContainer {
+func createFlexMemberMenuMessage(prof *profile.Profile) *linebot.BubbleContainer {
 	container := MegaBubbleContainer
 
 	container.Body = &linebot.BoxComponent{

--- a/pkg/infrastructure/line/menu_messege.go
+++ b/pkg/infrastructure/line/menu_messege.go
@@ -119,10 +119,10 @@ func createFlexMenuMessage() *linebot.BubbleContainer {
 	return &container
 }
 
-type Action func(string) *linebot.PostbackAction
+type PostbackActionGenerator func(string) *linebot.PostbackAction
 
 // CreateMemberSelectFlexMessageはメンバー選択画面を生成
-func CreateMemberSelectFlexMessage(action Action) linebot.SendingMessage {
+func CreateMemberSelectFlexMessage(action PostbackActionGenerator) linebot.SendingMessage {
 	container := createFlexMemberSelectMessage(action)
 
 	outerContainer := &linebot.CarouselContainer{
@@ -135,7 +135,7 @@ func CreateMemberSelectFlexMessage(action Action) linebot.SendingMessage {
 	return message
 }
 
-func createFlexMemberSelectMessage(action Action) []*linebot.BubbleContainer {
+func createFlexMemberSelectMessage(action PostbackActionGenerator) []*linebot.BubbleContainer {
 	contents := []*linebot.BubbleContainer{}
 	groupSize := 8
 

--- a/pkg/infrastructure/line/menu_messege.go
+++ b/pkg/infrastructure/line/menu_messege.go
@@ -309,10 +309,8 @@ func createFlexMemberMenuMessage(prof *profile.Profile) *linebot.BubbleContainer
 		},
 	}
 
-	generationLabelText := model.MemberToGenerationMap[prof.Name] + "期生"
-	generationLabel := CreateLabelComponent(generationLabelText, "#ffffff", "#EC3D44")
 	firstBox := container.Body.Contents[0].(*linebot.BoxComponent)
-	firstBox.Contents = append(firstBox.Contents, generationLabel)
+	firstBox.Contents = append(firstBox.Contents, CreateGenerationLabel(prof.Name, "#ffffff", "#EC3D44"))
 
 	return &container
 }

--- a/pkg/infrastructure/line/menu_messege.go
+++ b/pkg/infrastructure/line/menu_messege.go
@@ -2,8 +2,8 @@ package line
 
 import (
 	"fmt"
-	"notify/pkg/model"
-	"notify/pkg/profile"
+	"zephyr/pkg/model"
+	"zephyr/pkg/profile"
 
 	"github.com/line/line-bot-sdk-go/v7/linebot"
 )

--- a/pkg/infrastructure/line/message.go
+++ b/pkg/infrastructure/line/message.go
@@ -212,6 +212,7 @@ func createFlexImagesMessage(urls []string) []*linebot.BubbleContainer {
 	return contents
 }
 
+// CreateLabelComponent creates label component.
 func CreateLabelComponent(text, textcolor, backgroundcolor string) *linebot.BoxComponent {
 	return &linebot.BoxComponent{
 		Type:   linebot.FlexComponentTypeBox,

--- a/pkg/infrastructure/line/nickname_list_messege.go
+++ b/pkg/infrastructure/line/nickname_list_messege.go
@@ -114,10 +114,8 @@ func createFlexListMessage(prof *profile.Profile) *linebot.BubbleContainer {
 		},
 	}
 
-	generationLabelText := model.MemberToGenerationMap[prof.Name] + "期生"
-	generationLabel := CreateLabelComponent(generationLabelText, "#ffffff", "#EC3D44")
 	firstBox := container.Body.Contents[0].(*linebot.BoxComponent)
-	firstBox.Contents = append(firstBox.Contents, generationLabel)
+	firstBox.Contents = append(firstBox.Contents, CreateGenerationLabel(prof.Name, "#ffffff", "#EC3D44"))
 
 	return &container
 }

--- a/pkg/infrastructure/line/postback.go
+++ b/pkg/infrastructure/line/postback.go
@@ -67,18 +67,20 @@ const (
 	NicknameLabel    = "ニックネーム"
 )
 
+// NewSubscribeAction is the postback action that registers a member.
 func NewSubscribeAction(diaryMemberName string) *linebot.PostbackAction {
 	postBackMap := map[string]string{
 		MemberKey: model.NormalizeName(diaryMemberName),
 	}
 	dataString, err := NewPostbackDataString(PostbackActionRegister, postBackMap)
 	if err != nil {
-		fmt.Printf("newSubscribeAction: %v\n", err)
+		fmt.Printf("NewSubscribeAction: %v\n", err)
 		return nil
 	}
 	return NewPostbackAction(SubscribeLabel, dataString, SubscribeLabel)
 }
 
+// newUnsubscribeAction is the postback action that unregisters a member.
 func newUnsubscribeAction(diaryMemberName string) *linebot.PostbackAction {
 	postBackMap := map[string]string{
 		MemberKey: model.NormalizeName(diaryMemberName),
@@ -91,6 +93,7 @@ func newUnsubscribeAction(diaryMemberName string) *linebot.PostbackAction {
 	return NewPostbackAction(UnsubscribeLabel, dataString, UnsubscribeLabel)
 }
 
+// NewBlogAction is the postback action that shows the latest blog entry of the specified member.
 func NewBlogAction(diaryMemberName string) *linebot.PostbackAction {
 	postBackMap := map[string]string{
 		MemberKey: model.NormalizeName(diaryMemberName),
@@ -103,37 +106,40 @@ func NewBlogAction(diaryMemberName string) *linebot.PostbackAction {
 	return NewPostbackAction(BlogLabel, dataString, BlogLabel)
 }
 
+// NewProfileAction is the postback action that shows the profile of the specified member.
 func NewProfileAction(diaryMemberName string) *linebot.PostbackAction {
 	postBackMap := map[string]string{
 		MemberKey: model.NormalizeName(diaryMemberName),
 	}
 	dataString, err := NewPostbackDataString(PostbackActionProfile, postBackMap)
 	if err != nil {
-		fmt.Printf("NewBlogAction: %v\n", err)
+		fmt.Printf("NewProfileAction: %v\n", err)
 		return nil
 	}
 	return NewPostbackAction(ProfileLabel, dataString, ProfileLabel)
 }
 
+// NewNicknameAction is the postback action that shows the nickname of the specified member.
 func NewNicknameAction(diaryMemberName string) *linebot.PostbackAction {
 	postBackMap := map[string]string{
 		MemberKey: model.NormalizeName(diaryMemberName),
 	}
 	dataString, err := NewPostbackDataString(PostbackActionNickname, postBackMap)
 	if err != nil {
-		fmt.Printf("NewBlogAction: %v\n", err)
+		fmt.Printf("NewNicknameAction: %v\n", err)
 		return nil
 	}
 	return NewPostbackAction(NicknameLabel, dataString, NicknameLabel)
 }
 
+// NewSelectAction is the postback action that shows the selectmenu of the member.
 func NewSelectAction(action string) *linebot.PostbackAction {
 	postBackMap := map[string]string{
 		ActionKey: action,
 	}
 	dataString, err := NewPostbackDataString(PostbackActionSelect, postBackMap)
 	if err != nil {
-		fmt.Printf("NewBlogAction: %v\n", err)
+		fmt.Printf("NewSelectAction: %v\n", err)
 		return nil
 	}
 	return NewPostbackAction(action, dataString, action)

--- a/pkg/infrastructure/line/postback.go
+++ b/pkg/infrastructure/line/postback.go
@@ -133,14 +133,14 @@ func NewNicknameAction(diaryMemberName string) *linebot.PostbackAction {
 }
 
 // NewSelectAction is the postback action that shows the selectmenu of the member.
-func NewSelectAction(action string) *linebot.PostbackAction {
+func NewSelectAction(label string) *linebot.PostbackAction {
 	postBackMap := map[string]string{
-		ActionKey: action,
+		ActionKey: label,
 	}
 	dataString, err := NewPostbackDataString(PostbackActionSelect, postBackMap)
 	if err != nil {
 		fmt.Printf("NewSelectAction: %v\n", err)
 		return nil
 	}
-	return NewPostbackAction(action, dataString, action)
+	return NewPostbackAction(label, dataString, label)
 }

--- a/pkg/infrastructure/line/postback.go
+++ b/pkg/infrastructure/line/postback.go
@@ -22,9 +22,11 @@ const (
 	PostbackActionBlog       PostbackAction = "blog"
 	PostbackActionProfile    PostbackAction = "prof"
 	PostbackActionNickname   PostbackAction = "name"
+	PostbackActionSelect     PostbackAction = "select"
 )
 
 const MemberKey = "member"
+const ActionKey = "action"
 
 // ParsePostbackData parses the postback data.
 func ParsePostbackData(event *linebot.Event) (*PostbackData, error) {
@@ -62,7 +64,7 @@ const (
 	UnsubscribeLabel = "解除する"
 	BlogLabel        = "最新のブログ"
 	ProfileLabel     = "プロフィール"
-	NickanameLabel   = "ニックネーム"
+	NicknameLabel    = "ニックネーム"
 )
 
 func NewSubscribeAction(diaryMemberName string) *linebot.PostbackAction {
@@ -122,5 +124,17 @@ func NewNicknameAction(diaryMemberName string) *linebot.PostbackAction {
 		fmt.Printf("NewBlogAction: %v\n", err)
 		return nil
 	}
-	return NewPostbackAction(NickanameLabel, dataString, NickanameLabel)
+	return NewPostbackAction(NicknameLabel, dataString, NicknameLabel)
+}
+
+func NewSelectAction(action string) *linebot.PostbackAction {
+	postBackMap := map[string]string{
+		ActionKey: action,
+	}
+	dataString, err := NewPostbackDataString(PostbackActionSelect, postBackMap)
+	if err != nil {
+		fmt.Printf("NewBlogAction: %v\n", err)
+		return nil
+	}
+	return NewPostbackAction(action, dataString, action)
 }

--- a/pkg/infrastructure/line/postback.go
+++ b/pkg/infrastructure/line/postback.go
@@ -19,6 +19,9 @@ type PostbackAction string
 const (
 	PostbackActionRegister   PostbackAction = "reg"
 	PostbackActionUnregister PostbackAction = "unreg"
+	PostbackActionBlog       PostbackAction = "blog"
+	PostbackActionProfile    PostbackAction = "prof"
+	PostbackActionNickname   PostbackAction = "name"
 )
 
 const MemberKey = "member"
@@ -57,6 +60,9 @@ const (
 	ThumbDownLabel   = "👎"
 	SubscribeLabel   = "購読する"
 	UnsubscribeLabel = "解除する"
+	BlogLabel        = "最新のブログ"
+	ProfileLabel     = "プロフィール"
+	NickanameLabel   = "ニックネーム"
 )
 
 func NewSubscribeAction(diaryMemberName string) *linebot.PostbackAction {
@@ -81,4 +87,40 @@ func newUnsubscribeAction(diaryMemberName string) *linebot.PostbackAction {
 		return nil
 	}
 	return NewPostbackAction(UnsubscribeLabel, dataString, UnsubscribeLabel)
+}
+
+func NewBlogAction(diaryMemberName string) *linebot.PostbackAction {
+	postBackMap := map[string]string{
+		MemberKey: model.NormalizeName(diaryMemberName),
+	}
+	dataString, err := NewPostbackDataString(PostbackActionBlog, postBackMap)
+	if err != nil {
+		fmt.Printf("NewBlogAction: %v\n", err)
+		return nil
+	}
+	return NewPostbackAction(BlogLabel, dataString, BlogLabel)
+}
+
+func NewProfileAction(diaryMemberName string) *linebot.PostbackAction {
+	postBackMap := map[string]string{
+		MemberKey: model.NormalizeName(diaryMemberName),
+	}
+	dataString, err := NewPostbackDataString(PostbackActionProfile, postBackMap)
+	if err != nil {
+		fmt.Printf("NewBlogAction: %v\n", err)
+		return nil
+	}
+	return NewPostbackAction(ProfileLabel, dataString, ProfileLabel)
+}
+
+func NewNicknameAction(diaryMemberName string) *linebot.PostbackAction {
+	postBackMap := map[string]string{
+		MemberKey: model.NormalizeName(diaryMemberName),
+	}
+	dataString, err := NewPostbackDataString(PostbackActionNickname, postBackMap)
+	if err != nil {
+		fmt.Printf("NewBlogAction: %v\n", err)
+		return nil
+	}
+	return NewPostbackAction(NickanameLabel, dataString, NickanameLabel)
 }

--- a/pkg/infrastructure/line/profile_messege.go
+++ b/pkg/infrastructure/line/profile_messege.go
@@ -141,10 +141,15 @@ func createFlexProfileMessage(prof *profile.Profile) *linebot.BubbleContainer {
 		},
 	}
 
-	generationLabelText := model.MemberToGenerationMap[prof.Name] + "期生"
-	generationLabel := CreateLabelComponent(generationLabelText, "#ffffff", "#EC3D44")
 	firstBox := container.Body.Contents[0].(*linebot.BoxComponent)
-	firstBox.Contents = append(firstBox.Contents, generationLabel)
+	firstBox.Contents = append(firstBox.Contents, CreateGenerationLabel(prof.Name, "#ffffff", "#EC3D44"))
 
 	return &container
+}
+
+func CreateGenerationLabel(name, textcolor, backgroundcolor string) *linebot.BoxComponent {
+	generationText := model.MemberToGenerationMap[name] + "期生"
+	generationLabel := CreateLabelComponent(generationText, textcolor, backgroundcolor)
+
+	return generationLabel
 }

--- a/pkg/infrastructure/line/profile_messege.go
+++ b/pkg/infrastructure/line/profile_messege.go
@@ -147,6 +147,7 @@ func createFlexProfileMessage(prof *profile.Profile) *linebot.BubbleContainer {
 	return &container
 }
 
+// CreateGenerationLabel creates generation label component of specified member.
 func CreateGenerationLabel(name, textcolor, backgroundcolor string) *linebot.BoxComponent {
 	generationText := model.MemberToGenerationMap[name] + "期生"
 	generationLabel := CreateLabelComponent(generationText, textcolor, backgroundcolor)


### PR DESCRIPTION
## 🎯 目的

コマンド入力だけではなく画面操作で従来のコマンドを実行できるメニュー画面の作成
![image](https://github.com/soya111/lambda/assets/142418961/fee5fc74-a1b0-443f-93ba-4242a2cb3195)

## 🔍 変更の詳細

✅ メニュー画面を得るMenuCommandの作成

✅ 各コマンドに対応するポストバックアクションの作成

## ⚠️ 影響範囲

なし

## 🔗 関連Issue

- 関連Issue: #76

## 追記
メンバー名も選択することができる汎用メニュー画面を作成しました
![S__24338523](https://github.com/soya111/lambda/assets/142418961/8f51f8d5-f64c-4024-afa1-0713db0c2213)

