### PR TITLE
variable number of members

### DIFF
--- a/pkg/infrastructure/line/menu_message.go
+++ b/pkg/infrastructure/line/menu_message.go
@@ -147,6 +147,7 @@ func createFlexMemberSelectMessage(action PostbackActionGenerator) []*linebot.Bu
 		if end > len(model.MemberList) {
 			end = len(model.MemberList)
 		}
+
 		group := model.MemberList[i:end]
 
 		for _, member := range group {
@@ -180,7 +181,6 @@ func createFlexMemberSelectMessage(action PostbackActionGenerator) []*linebot.Bu
 		content.Body = &linebot.BoxComponent{
 			Type:       linebot.FlexComponentTypeBox,
 			Layout:     linebot.FlexBoxLayoutTypeVertical,
-			Height:     "410px",
 			PaddingAll: "0px",
 			Contents: []linebot.FlexComponent{
 				&linebot.BoxComponent{
@@ -189,16 +189,17 @@ func createFlexMemberSelectMessage(action PostbackActionGenerator) []*linebot.Bu
 					Contents:        components,
 					PaddingAll:      "20px",
 					BackgroundColor: "#464F69",
-					Position:        linebot.FlexComponentPositionTypeAbsolute,
+					Position:        linebot.FlexComponentPositionTypeRelative,
+					JustifyContent:  linebot.FlexComponentJustifyContentTypeFlexStart,
 					OffsetBottom:    "0px",
 					OffsetStart:     "0px",
 					OffsetEnd:       "0px",
 				},
 			},
+			BackgroundColor: "#464F69",
 		}
 		contents = append(contents, &content)
 	}
-
 	return contents
 }
 


### PR DESCRIPTION
## 🎯 目的

メンバー数が8n人でない場合でもメンバーセレクト画面が正常に表示されるようにしました。

## 🔍 変更の詳細

✅ メンバー数が8n人を想定していたが、バリアブルなメンバー数に対応した。

## ⚠️ 影響範囲

メンバーセレクトメニュー

## 🚀 テスト

🔧 メンバーリストからメンバーを数名コメントアウトしてテストに成功

![image](https://github.com/soya111/lambda/assets/142418961/a711ae83-52c3-403b-bd63-189679f7d581)

