### PR TITLE
get specific blog

### DIFF
--- a/app/webhook/command_handler.go
+++ b/app/webhook/command_handler.go
@@ -210,7 +210,18 @@ func (c *BlogCommand) Execute(ctx context.Context, event *linebot.Event, args []
 	}
 
 	if !model.IsMember(member) {
-		if err := c.bot.ReplyTextMessages(ctx, event.ReplyToken, fmt.Sprintf("%sは存在しません。", member)); err != nil {
+		scraper := blog.NewHinatazakaScraper()
+		diary, err := scraper.GetSpecificDiaryById(member)
+		if err != nil {
+			if err := c.bot.ReplyTextMessages(ctx, event.ReplyToken, fmt.Sprintf("%sは存在しません。", member)); err != nil {
+				return fmt.Errorf("BlogCommand.Execute: %w", err)
+			}
+			return nil
+		}
+		message := line.CreateFlexMessage(diary)
+
+		err = c.bot.ReplyMessage(ctx, event.ReplyToken, message)
+		if err != nil {
 			return fmt.Errorf("BlogCommand.Execute: %w", err)
 		}
 		return nil

--- a/app/webhook/command_handler.go
+++ b/app/webhook/command_handler.go
@@ -188,7 +188,7 @@ func (c *HelpCommand) Description() string {
 	return "Show the list of available commands. Usage: help"
 }
 
-// BlogCommand is the command that shows the latest blog entry of the specified member.
+// BlogCommand is the command that shows the latest blog entry of the specified member or shows the specific blog from blog id.
 type BlogCommand struct {
 	bot *line.Linebot
 }

--- a/pkg/blog/hinatazaka_scraper.go
+++ b/pkg/blog/hinatazaka_scraper.go
@@ -2,9 +2,7 @@ package blog
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"regexp"
 	"zephyr/pkg/infrastructure/scrape"
 	"zephyr/pkg/model"
 
@@ -163,14 +161,6 @@ func (s *HinatazakaScraper) parseDiaryFromSelection(sl *goquery.Selection) (*Scr
 
 // GetSpecificDiaryById returns the specific diary from blog id.
 func (s *HinatazakaScraper) GetSpecificDiaryById(blogId string) (*ScrapedDiary, error) {
-	pattern := `^\d{5}$`
-	regex := regexp.MustCompile(pattern)
-
-	if !regex.MatchString(blogId) {
-		err := errors.New("invalid blog id")
-		return nil, err
-	}
-
 	url := "https://www.hinatazaka46.com/s/official/diary/detail/" + blogId + "?ima=0000&cd=member"
 
 	document, err := scrape.GetDocumentFromURL(url)

--- a/pkg/blog/hinatazaka_scraper.go
+++ b/pkg/blog/hinatazaka_scraper.go
@@ -2,7 +2,9 @@ package blog
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"regexp"
 	"zephyr/pkg/infrastructure/scrape"
 	"zephyr/pkg/model"
 
@@ -155,6 +157,69 @@ func (s *HinatazakaScraper) parseDiaryFromSelection(sl *goquery.Selection) (*Scr
 	}
 
 	diary := NewScrapedDiary(RootURL+href, title, name, date, diaryId, images, lead)
+
+	return diary, nil
+}
+
+// GetSpecificDiaryById returns the specific diary from blog id.
+func (s *HinatazakaScraper) GetSpecificDiaryById(blogId string) (*ScrapedDiary, error) {
+	pattern := `^\d{5}$`
+	regex := regexp.MustCompile(pattern)
+
+	if !regex.MatchString(blogId) {
+		err := errors.New("invalid blog id")
+		return nil, err
+	}
+
+	url := "https://www.hinatazaka46.com/s/official/diary/detail/" + blogId + "?ima=0000&cd=member"
+
+	document, err := scrape.GetDocumentFromURL(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get document from url %s: %w", url, err)
+	}
+
+	article := document.Find(".p-blog-article").First()
+
+	diary, err := s.parseSpecificDiaryFromSelection(blogId, article)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse diary from selection: %w", err)
+	}
+
+	memberId, err := model.GetMemberId(diary.MemberName)
+	if err != nil {
+		return nil, err
+	}
+
+	diary.SetMemberIcon(s.GetIconURLByID(document, memberId))
+
+	return diary, nil
+}
+
+func (s *HinatazakaScraper) parseSpecificDiaryFromSelection(blogId string, sl *goquery.Selection) (*ScrapedDiary, error) {
+	url := "https://www.hinatazaka46.com/s/official/diary/detail/" + blogId + "?ima=0000&cd=member"
+	title := strings.TrimSpace(sl.Find(".c-blog-article__title").Text())
+	name := strings.TrimSpace(sl.Find(".c-blog-article__name").Text())
+	diaryId, _ := strconv.Atoi(blogId)
+
+	date, err := time.Parse(model.TimeFmt, strings.TrimSpace(sl.Find(".c-blog-article__date").Text())+" (JST)")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	images := s.GetImages(&goquery.Document{Selection: sl})
+
+	opt := scrape.TextExtractionOptions{
+		MaxLength:       50,
+		IncludeNewlines: false,
+		AppendEllipsis:  true,
+	}
+
+	lead, err := scrape.ExtractAndFormatTextFromElement(&goquery.Document{Selection: sl}, ".c-blog-article__text", opt)
+	if err != nil {
+		fmt.Printf("error extracting text from element: %v\n", err)
+	}
+
+	diary := NewScrapedDiary(url, title, name, date, diaryId, images, lead)
 
 	return diary, nil
 }


### PR DESCRIPTION
## 🎯 目的

ブログIdから特定のブログを取得する機能を追加しました。
これにより、最新ではないブログの写真等を見れたり、デバッグで便利だったりします。

## 🔍 変更の詳細

✅ ブログIdから特定のブログをスクレイピングするメソッドの追加

✅ ブログコマンドとの機能統合

## ⚠️ 影響範囲

ブログコマンド

## 🚀 テスト

🔧 有効な5桁のブログIdでのテストに成功

🔧 無効な入力は今まで通り存在しないメンバーとして処理に成功

## 🔗 関連Issue

このPRに関連するIssueやタスクのリンクを以下のフォーマットで記述します。

- 関連Issue: #77 

![image](https://github.com/soya111/lambda/assets/142418961/e42f1807-24d2-46d8-a138-4c0f731b9a81)